### PR TITLE
Moved the create workflow step template to create workflow menu

### DIFF
--- a/components/userfunctions/create/create.php
+++ b/components/userfunctions/create/create.php
@@ -34,7 +34,7 @@
 
 <!-- Action Panel -->
 <div class="w3-row-padding w3-margin-bottom">
-    <div class="w3-quarter" onclick="window.location.href='./dashboard.php?content=create&contentType=app'">
+    <div class="w3-quarter" onclick="window.location.href='./dashboard.php?content=create&contentType=workflow'">
     <div class="w3-container w3-teal w3-padding-16 w3-border">
         <div class="w3-left"><i class="fa fa-share-alt w3-xxxlarge"></i></div>
         <div class="w3-clear"><h5>Workflow</h5></div>

--- a/components/userfunctions/search/searchWorkflowTemplates.php
+++ b/components/userfunctions/search/searchWorkflowTemplates.php
@@ -7,7 +7,7 @@
 
 <!-- Workflow Template Search -->
 <div id="workflowTemplateSearch" class="w3-card-4 w3-padding w3-margin">
-    <button class="w3-button w3-right w3-blue" type="button" onclick="window.location.href='./dashboard.php?content=create&contentType=workflow'">Start Workflow Template</button>
+    <button class="w3-button w3-right w3-blue" type="button" onclick="window.location.href='./dashboard.php?content=create&contentType=app'">Start Workflow Template</button>
     <h5>Workflow Template Search</h5>
     <p>You may search by any field in the table.</p>
     <input id="workflowInput" type="text" onkeyup="search('workflowTable', 'workflowInput')"></input>


### PR DESCRIPTION
The create workflow step template (drag and drop) was previously hidden in the search menu. Now it appears under the create menu for workflows.